### PR TITLE
google colabでプログレスバーを正しく表示するための修正。

### DIFF
--- a/libs/operate_df.py
+++ b/libs/operate_df.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import os
 import sys
 


### PR DESCRIPTION
プログレスバーをGoogle Colab上で正しく表示させるために、モジュールを変更。
![image](https://github.com/okuokuch/calc_damage_for_pokemon/assets/94620772/086ae618-9742-4619-8a51-6ff9695abcf8)
